### PR TITLE
Chapter11 Adding Search and Pagination

### DIFF
--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -5,6 +5,7 @@ import { CreateInvoice } from '@/app/ui/invoices/buttons'
 import { lusitana } from '@/app/ui/fonts'
 import { InvoicesTableSkeleton } from '@/app/ui/skeletons'
 import { Suspense } from 'react'
+import { fetchInvoicesPages } from '@/app/lib/data'
 
 export default async function Page(props: {
   searchParams?: Promise<{
@@ -15,6 +16,7 @@ export default async function Page(props: {
   const searchParams = await props.searchParams
   const query = searchParams?.query || ''
   const currentPage = Number(searchParams?.page) || 1
+  const totalPages = await fetchInvoicesPages(query)
 
   return (
     <div className="w-full">
@@ -25,11 +27,11 @@ export default async function Page(props: {
         <Search placeholder="Search invoices..." />
         <CreateInvoice />
       </div>
-       <Suspense key={query + currentPage} fallback={<InvoicesTableSkeleton />}>
+      <Suspense key={query + currentPage} fallback={<InvoicesTableSkeleton />}>
         <Table query={query} currentPage={currentPage} />
       </Suspense>
       <div className="mt-5 flex w-full justify-center">
-        {/* <Pagination totalPages={totalPages} /> */}
+        <Pagination totalPages={totalPages} />
       </div>
     </div>
   )

--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -1,3 +1,28 @@
-export default function Page() {
-  return <p>invoices Page</p>
+import Pagination from '@/app/ui/invoices/pagination'
+import Search from '@/app/ui/search'
+import Table from '@/app/ui/invoices/table'
+import { CreateInvoice } from '@/app/ui/invoices/buttons'
+import { lusitana } from '@/app/ui/fonts'
+import { InvoicesTableSkeleton } from '@/app/ui/skeletons'
+import { Suspense } from 'react'
+
+export default async function Page() {
+  
+  return (
+    <div className="w-full">
+      <div className="flex w-full items-center justify-between">
+        <h1 className={`${lusitana.className} text-2xl`}>Invoices</h1>
+      </div>
+      <div className="mt-4 flex items-center justify-between gap-2 md:mt-8">
+        <Search placeholder="Search invoices..." />
+        <CreateInvoice />
+      </div>
+      {/*  <Suspense key={query + currentPage} fallback={<InvoicesTableSkeleton />}>
+        <Table query={query} currentPage={currentPage} />
+      </Suspense> */}
+      <div className="mt-5 flex w-full justify-center">
+        {/* <Pagination totalPages={totalPages} /> */}
+      </div>
+    </div>
+  )
 }

--- a/app/dashboard/invoices/page.tsx
+++ b/app/dashboard/invoices/page.tsx
@@ -6,8 +6,16 @@ import { lusitana } from '@/app/ui/fonts'
 import { InvoicesTableSkeleton } from '@/app/ui/skeletons'
 import { Suspense } from 'react'
 
-export default async function Page() {
-  
+export default async function Page(props: {
+  searchParams?: Promise<{
+    query?: string
+    page?: string
+  }>
+}) {
+  const searchParams = await props.searchParams
+  const query = searchParams?.query || ''
+  const currentPage = Number(searchParams?.page) || 1
+
   return (
     <div className="w-full">
       <div className="flex w-full items-center justify-between">
@@ -17,9 +25,9 @@ export default async function Page() {
         <Search placeholder="Search invoices..." />
         <CreateInvoice />
       </div>
-      {/*  <Suspense key={query + currentPage} fallback={<InvoicesTableSkeleton />}>
+       <Suspense key={query + currentPage} fallback={<InvoicesTableSkeleton />}>
         <Table query={query} currentPage={currentPage} />
-      </Suspense> */}
+      </Suspense>
       <div className="mt-5 flex w-full justify-center">
         {/* <Pagination totalPages={totalPages} /> */}
       </div>

--- a/app/ui/invoices/pagination.tsx
+++ b/app/ui/invoices/pagination.tsx
@@ -4,17 +4,24 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@heroicons/react/24/outline';
 import clsx from 'clsx';
 import Link from 'next/link';
 import { generatePagination } from '@/app/lib/utils';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 export default function Pagination({ totalPages }: { totalPages: number }) {
-  // NOTE: Uncomment this code in Chapter 11
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentPage = Number(searchParams.get('page')) || 1;
 
-  // const allPages = generatePagination(currentPage, totalPages);
+  const createPageURL = (pageNumber: number | string) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('page', pageNumber.toString());
+    return `${pathname}?${params.toString()}`;
+  };
+
+  const allPages = generatePagination(currentPage, totalPages);
 
   return (
     <>
-      {/*  NOTE: Uncomment this code in Chapter 11 */}
-
-      {/* <div className="inline-flex">
+      <div className="inline-flex">
         <PaginationArrow
           direction="left"
           href={createPageURL(currentPage - 1)}
@@ -47,7 +54,7 @@ export default function Pagination({ totalPages }: { totalPages: number }) {
           href={createPageURL(currentPage + 1)}
           isDisabled={currentPage >= totalPages}
         />
-      </div> */}
+      </div>
     </>
   );
 }

--- a/app/ui/search.tsx
+++ b/app/ui/search.tsx
@@ -11,6 +11,7 @@ export default function Search({ placeholder }: { placeholder: string }) {
 
   const handleSearch = useDebouncedCallback((term) => {
     const params = new URLSearchParams(searchParams)
+    params.set('page', '1')
     if (term) {
       params.set('query', term)
     } else {

--- a/app/ui/search.tsx
+++ b/app/ui/search.tsx
@@ -2,13 +2,14 @@
 
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useDebouncedCallback } from 'use-debounce'
 
 export default function Search({ placeholder }: { placeholder: string }) {
   const searchParams = useSearchParams()
   const pathname = usePathname()
   const { replace } = useRouter()
 
-  function handleSearch(term: string) {
+  const handleSearch = useDebouncedCallback((term) => {
     const params = new URLSearchParams(searchParams)
     if (term) {
       params.set('query', term)
@@ -16,7 +17,7 @@ export default function Search({ placeholder }: { placeholder: string }) {
       params.delete('query')
     }
     replace(`${pathname}?${params.toString()}`)
-  }
+  }, 300)
 
   return (
     <div className="relative flex flex-1 flex-shrink-0">

--- a/app/ui/search.tsx
+++ b/app/ui/search.tsx
@@ -1,8 +1,23 @@
-'use client';
+'use client'
 
-import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 export default function Search({ placeholder }: { placeholder: string }) {
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  const { replace } = useRouter()
+
+  function handleSearch(term: string) {
+    const params = new URLSearchParams(searchParams)
+    if (term) {
+      params.set('query', term)
+    } else {
+      params.delete('query')
+    }
+    replace(`${pathname}?${params.toString()}`)
+  }
+
   return (
     <div className="relative flex flex-1 flex-shrink-0">
       <label htmlFor="search" className="sr-only">
@@ -11,8 +26,12 @@ export default function Search({ placeholder }: { placeholder: string }) {
       <input
         className="peer block w-full rounded-md border border-gray-200 py-[9px] pl-10 text-sm outline-2 placeholder:text-gray-500"
         placeholder={placeholder}
+        onChange={(e) => {
+          handleSearch(e.target.value)
+        }}
+        defaultValue={searchParams.get('query')?.toString()}
       />
       <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500 peer-focus:text-gray-900" />
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## 📗 [Adding Search and Pagination](https://nextjs.org/learn/dashboard-app/adding-search-and-pagination)

### 🔎 학습 내용
#### search params를 쓰는 법
1. client
    1. useSearchParams : 현 URL의 parameter에 접근
        ex. ```/dashboard/invoices?page=1&query=pending``` =>  ```{page: '1', query: 'pending'}```
    2. usePathname : URL의 경로명을 반환
        ex. ```/dashboard/invoices``` =>  ```/dashboard/invoices```
    3. useRouter : routing 관련 매소드들을 반환
    
2. server
    1. Page.tsx에서 Props로 [params/searchParams](https://nextjs.org/docs/app/api-reference/file-conventions/page)를 받을 수 있다.

### ➕ 추가로 공부해볼 것
- [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams)